### PR TITLE
Convert `Ratings` & `Repos` to MUI Cards

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/client/src/components/Cockpit/Cockpit.js
+++ b/client/src/components/Cockpit/Cockpit.js
@@ -9,6 +9,7 @@ import Typography from '@material-ui/core/Typography';
 import GitHubIcon from '@material-ui/icons/GitHub';
 
 import Ratings from '../Ratings/Ratings';
+import Repos from '../Repos/Repos';
 
 export default function Cockpit() {
 	const [myRepos, setMyRepos] = useState({ data: [] });
@@ -68,6 +69,7 @@ export default function Cockpit() {
 					cockpitDeleteCallback={ratingDeleted}
 				/>
 				<Typography variant='h4'>My Repos</Typography>
+				<Repos />
 				<ul>
 					{myRepos &&
 						myRepos.data.map((repo, index) => (

--- a/client/src/components/Cockpit/Cockpit.js
+++ b/client/src/components/Cockpit/Cockpit.js
@@ -69,20 +69,7 @@ export default function Cockpit() {
 					cockpitDeleteCallback={ratingDeleted}
 				/>
 				<Typography variant='h4'>My Repos</Typography>
-				<Repos />
-				<ul>
-					{myRepos &&
-						myRepos.data.map((repo, index) => (
-							<li key={index}>
-								<div>
-									<a href={repo.html_url}>{repo.name}</a>
-									{repo.description && (
-										<p>{repo.description}</p>
-									)}
-								</div>
-							</li>
-						))}
-				</ul>
+				<Repos repos={myRepos.data} />
 			</div>
 		</div>
 	);

--- a/client/src/components/Ratings/Rating/Rating.js
+++ b/client/src/components/Ratings/Rating/Rating.js
@@ -16,7 +16,9 @@ export default function Rating(props) {
 		<Card style={{ height: '100%' }} className={'card'}>
 			<Typography variant='body1'>User: {props.user}</Typography>
 			<Typography variant='body1'>Rating: {props.rating}</Typography>
-			<Button onClick={deleteRating}>x</Button>
+			<Button onClick={deleteRating} variant='contained' size='small'>
+				x
+			</Button>
 		</Card>
 	);
 }

--- a/client/src/components/Ratings/Rating/Rating.js
+++ b/client/src/components/Ratings/Rating/Rating.js
@@ -4,18 +4,19 @@ import React from 'react';
 import axios from 'axios';
 import envs from '../../../envs/envs';
 
+import './Rating.scss';
+import Card from '@material-ui/core/Card';
+
 export default function Rating(props) {
 	async function deleteRating() {
 		await axios.delete(`${envs}/ratings/${props.id}`);
 		props.deleteRating();
 	}
 	return (
-		<div>
-			<div style={{ margin: '2px' }}>
-				<Typography variant='body1'>User: {props.user}</Typography>
-				<Typography variant='body1'>Rating: {props.rating}</Typography>
-				<Button onClick={deleteRating}>x</Button>
-			</div>
-		</div>
+		<Card style={{ height: '100%' }} className={'card'}>
+			<Typography variant='body1'>User: {props.user}</Typography>
+			<Typography variant='body1'>Rating: {props.rating}</Typography>
+			<Button onClick={deleteRating}>x</Button>
+		</Card>
 	);
 }

--- a/client/src/components/Ratings/Rating/Rating.js
+++ b/client/src/components/Ratings/Rating/Rating.js
@@ -6,6 +6,7 @@ import envs from '../../../envs/envs';
 
 import './Rating.scss';
 import Card from '@material-ui/core/Card';
+import MUIRating from '@material-ui/lab/Rating';
 
 export default function Rating(props) {
 	async function deleteRating() {
@@ -15,10 +16,12 @@ export default function Rating(props) {
 	return (
 		<Card style={{ height: '100%' }} className={'card'}>
 			<Typography variant='body1'>User: {props.user}</Typography>
-			<Typography variant='body1'>Rating: {props.rating}</Typography>
-			<Button onClick={deleteRating} variant='contained' size='small'>
-				x
-			</Button>
+			<MUIRating readOnly value={props.rating} />
+			<div>
+				<Button onClick={deleteRating} variant='contained' size='small'>
+					x
+				</Button>
+			</div>
 		</Card>
 	);
 }

--- a/client/src/components/Ratings/Rating/Rating.scss
+++ b/client/src/components/Ratings/Rating/Rating.scss
@@ -1,0 +1,5 @@
+.card {
+	max-width: 350px;
+	box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.3);
+	background-color: #fafafa;
+}

--- a/client/src/components/Ratings/Rating/Rating.scss
+++ b/client/src/components/Ratings/Rating/Rating.scss
@@ -1,5 +1,0 @@
-.card {
-	max-width: 350px;
-	box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.3);
-	background-color: #fafafa;
-}

--- a/client/src/components/Ratings/Ratings.js
+++ b/client/src/components/Ratings/Ratings.js
@@ -4,20 +4,56 @@ import CreateRating from './CreateRating/CreateRating';
 
 import Rating from './Rating/Rating';
 
+import Grid from '@material-ui/core/Grid';
+
+import { makeStyles } from '@material-ui/core/styles';
+
+import clsx from 'clsx';
+
+const useStyles = makeStyles((theme) => ({
+	root: {
+		display: 'flex',
+		justifyContent: 'center',
+		flexWrap: 'wrap',
+		'& > *': {
+			margin: theme.spacing(0.5),
+		},
+	},
+}));
+
 export default function Ratings(props) {
+	const classes = useStyles();
 	return (
 		<div>
 			<Typography variant='h4'>Ratings</Typography>
-			{props.ratings &&
-				props.ratings.map((rating, index) => (
-					<Rating
-						user={rating.user}
-						rating={rating.rating}
-						key={index}
-						id={rating._id}
-						deleteRating={props.cockpitDeleteCallback}
-					/>
-				))}
+			<Grid
+				container
+				spacing={4}
+				className={clsx('grid-container', classes.root)}
+				style={{ marginBottom: '1rem' }}
+			>
+				{props.ratings &&
+					props.ratings.map((rating, index) => (
+						<Grid
+							item
+							xs={12}
+							sm={4}
+							md={4}
+							lg={3}
+							key={index}
+							align='center'
+						>
+							<Rating
+								user={rating.user}
+								rating={rating.rating}
+								key={index}
+								id={rating._id}
+								deleteRating={props.cockpitDeleteCallback}
+							/>
+						</Grid>
+					))}
+			</Grid>
+
 			<CreateRating ratingCreated={props.cockpitCreateCallback} />
 		</div>
 	);

--- a/client/src/components/Repos/Repo/Repo.js
+++ b/client/src/components/Repos/Repo/Repo.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Repo() {
+	return (
+		<div>
+			<h5>Repo</h5>
+		</div>
+	);
+}

--- a/client/src/components/Repos/Repo/Repo.js
+++ b/client/src/components/Repos/Repo/Repo.js
@@ -1,12 +1,18 @@
 import React from 'react';
+import Card from '@material-ui/core/Card';
+import './Repo.scss';
+import { Typography } from '@material-ui/core';
+import GitHubIcon from '@material-ui/icons/GitHub';
 
 export default function Repo(props) {
 	return (
-		<li>
-			<div>
-				<a href={props.repo.html_url}>{props.repo.name}</a>
-				{props.repo.description && <p>{props.repo.description}</p>}
-			</div>
-		</li>
+		<Card style={{ height: '100%' }} className={'card'}>
+			<Typography variant='body1'>
+				<a href={props.repo.html_url}>
+					{props.repo.name} <GitHubIcon />
+				</a>
+			</Typography>
+			{props.repo.description && <p>{props.repo.description}</p>}
+		</Card>
 	);
 }

--- a/client/src/components/Repos/Repo/Repo.js
+++ b/client/src/components/Repos/Repo/Repo.js
@@ -1,9 +1,12 @@
 import React from 'react';
 
-export default function Repo() {
+export default function Repo(props) {
 	return (
-		<div>
-			<h5>Repo</h5>
-		</div>
+		<li>
+			<div>
+				<a href={props.repo.html_url}>{props.repo.name}</a>
+				{props.repo.description && <p>{props.repo.description}</p>}
+			</div>
+		</li>
 	);
 }

--- a/client/src/components/Repos/Repo/Repo.scss
+++ b/client/src/components/Repos/Repo/Repo.scss
@@ -1,0 +1,6 @@
+.card {
+	max-width: 350px;
+	box-shadow: 0 5px 8px 0 rgba(0, 0, 0, 0.3);
+	background-color: #fafafa;
+	padding: 4px;
+}

--- a/client/src/components/Repos/Repos.js
+++ b/client/src/components/Repos/Repos.js
@@ -1,14 +1,43 @@
 import React from 'react';
 import Repo from './Repo/Repo';
 
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+import clsx from 'clsx';
+
+const useStyles = makeStyles((theme) => ({
+	root: {
+		display: 'flex',
+		justifyContent: 'center',
+		flexWrap: 'wrap',
+		'& > *': {
+			margin: theme.spacing(0.5),
+		},
+	},
+}));
+
 export default function Repos(props) {
+	const classes = useStyles();
 	return (
-		<div>
+		<Grid
+			container
+			spacing={4}
+			className={clsx('grid-container', classes.root)}
+			style={{ marginBottom: '1rem' }}
+		>
 			{props.repos.map((repo, index) => (
-				<ul key={index}>
+				<Grid
+					item
+					key={index}
+					xs={12}
+					sm={4}
+					md={4}
+					lg={3}
+					align='center'
+				>
 					<Repo repo={repo} />
-				</ul>
+				</Grid>
 			))}
-		</div>
+		</Grid>
 	);
 }

--- a/client/src/components/Repos/Repos.js
+++ b/client/src/components/Repos/Repos.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import Repo from './Repo/Repo';
 
-export default function Repos() {
+export default function Repos(props) {
 	return (
 		<div>
-			<h4>Repos</h4>
-			<Repo />
-			<Repo />
+			{props.repos.map((repo, index) => (
+				<ul key={index}>
+					<Repo repo={repo} />
+				</ul>
+			))}
 		</div>
 	);
 }

--- a/client/src/components/Repos/Repos.js
+++ b/client/src/components/Repos/Repos.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Repo from './Repo/Repo';
+
+export default function Repos() {
+	return (
+		<div>
+			<h4>Repos</h4>
+			<Repo />
+			<Repo />
+		</div>
+	);
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1373,7 +1373,7 @@
     "@types/yargs" "^15.0.0"
     "chalk" "^4.0.0"
 
-"@material-ui/core@^4.0.0", "@material-ui/core@^4.11.3":
+"@material-ui/core@^4.0.0", "@material-ui/core@^4.11.3", "@material-ui/core@^4.9.10":
   "integrity" "sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw=="
   "resolved" "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz"
   "version" "4.11.3"
@@ -1397,6 +1397,17 @@
   "version" "4.11.2"
   dependencies:
     "@babel/runtime" "^7.4.4"
+
+"@material-ui/lab@^4.0.0-alpha.57":
+  "integrity" "sha512-qo/IuIQOmEKtzmRD2E4Aa6DB4A87kmY6h0uYhjUmrrgmEAgbbw9etXpWPVXuRK6AGIQCjFzV6WO2i21m1R4FCw=="
+  "resolved" "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz"
+  "version" "4.0.0-alpha.57"
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    "clsx" "^1.0.4"
+    "prop-types" "^15.7.2"
+    "react-is" "^16.8.0 || ^17.0.0"
 
 "@material-ui/styles@^4.11.3":
   "integrity" "sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg=="

--- a/index.js
+++ b/index.js
@@ -38,10 +38,13 @@ if (process.env.NODE_ENV === 'production') {
 
 app.get('/api/my_repos', async (req, res) => {
 	try {
+		// 27 per query is a bit arbitrary but it allows for seeing
+		// my 3601 iter3 and DBs final project
 		const repos = await octokit.request(
-			'GET /users/michael-small/repos?per_page=30&sort=pushed'
+			'GET /users/michael-small/repos?per_page=27&sort=pushed'
 		);
 		res.send(repos);
+		console.log(repos);
 	} catch (error) {
 		res.status(500).send();
 	}

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ if (process.env.NODE_ENV === 'production') {
 
 app.get('/api/my_repos', async (req, res) => {
 	try {
-		const repos = await octokit.request('GET /users/michael-small/repos');
+		const repos = await octokit.request(
+			'GET /users/michael-small/repos?per_page=30&sort=pushed'
+		);
 		res.send(repos);
 	} catch (error) {
 		res.status(500).send();


### PR DESCRIPTION
I broke up the listing of ratings and repos in `Cockpit FC` into `Ratings FC` and `Repos FC`, each mapping over respective `Rating FCs` and `Repo FCs`. 

Now they are grids of cards of each repo and rating. 

Rating numbers are also in MUI Reviews, which show up as stars. I still need to convert the input to make ratings use the star system picker. But this is fine for now and I am working on that in #29.