### PR TITLE
Move `useEffect` queries for each component to respective components

### DIFF
--- a/client/src/components/Cockpit/Cockpit.js
+++ b/client/src/components/Cockpit/Cockpit.js
@@ -15,14 +15,12 @@ import Login from '../Login/Login';
 import UserContext from '../../Context';
 
 export default function Cockpit() {
-	const [myRepos, setMyRepos] = useState({ data: [] });
 	const [ratings, setRatings] = useState([]);
 	const user = useContext(UserContext);
 
 	const [myCommits, setMyCommits] = useState([]);
 
 	useEffect(() => {
-		getMyRepos();
 		getMyCommits();
 		getRatings();
 
@@ -32,11 +30,6 @@ export default function Cockpit() {
 	async function getRatings() {
 		const ratingsRes = await axios.get(`${envs}/ratings`);
 		setRatings(ratingsRes.data);
-	}
-
-	async function getMyRepos() {
-		const myReposRes = await axios.get(`${envs}/api/my_repos`);
-		setMyRepos(myReposRes.data);
 	}
 
 	async function ratingCreated() {
@@ -94,7 +87,7 @@ export default function Cockpit() {
 					cockpitDeleteCallback={ratingDeleted}
 				/>
 				<Typography variant='h4'>My Repos</Typography>
-				<Repos repos={myRepos.data} />
+				<Repos />
 			</div>
 		</div>
 	);

--- a/client/src/components/Cockpit/Cockpit.js
+++ b/client/src/components/Cockpit/Cockpit.js
@@ -15,30 +15,13 @@ import Login from '../Login/Login';
 import UserContext from '../../Context';
 
 export default function Cockpit() {
-	const [ratings, setRatings] = useState([]);
 	const user = useContext(UserContext);
 
 	const [myCommits, setMyCommits] = useState([]);
 
 	useEffect(() => {
 		getMyCommits();
-		getRatings();
-
-		ratingCreated();
 	}, []);
-
-	async function getRatings() {
-		const ratingsRes = await axios.get(`${envs}/ratings`);
-		setRatings(ratingsRes.data);
-	}
-
-	async function ratingCreated() {
-		getRatings();
-	}
-
-	async function ratingDeleted() {
-		getRatings();
-	}
 
 	async function getMyCommits() {
 		const myCommitsRes = await axios.get(`${envs}/api/repo_commits`);
@@ -81,11 +64,7 @@ export default function Cockpit() {
 					))}
 				</ul>
 
-				<Ratings
-					ratings={ratings}
-					cockpitCreateCallback={ratingCreated}
-					cockpitDeleteCallback={ratingDeleted}
-				/>
+				<Ratings />
 				<Typography variant='h4'>My Repos</Typography>
 				<Repos />
 			</div>

--- a/client/src/components/Ratings/Ratings.js
+++ b/client/src/components/Ratings/Ratings.js
@@ -30,7 +30,6 @@ export default function Ratings(props) {
 
 	useEffect(() => {
 		getRatings();
-		ratingCreated();
 	}, []);
 
 	async function getRatings() {

--- a/client/src/components/Ratings/Ratings.js
+++ b/client/src/components/Ratings/Ratings.js
@@ -1,8 +1,10 @@
 import { Typography } from '@material-ui/core';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import CreateRating from './CreateRating/CreateRating';
 
 import Rating from './Rating/Rating';
+import envs from '../../envs/envs';
+import axios from 'axios';
 
 import Grid from '@material-ui/core/Grid';
 
@@ -23,6 +25,27 @@ const useStyles = makeStyles((theme) => ({
 
 export default function Ratings(props) {
 	const classes = useStyles();
+
+	const [ratings, setRatings] = useState([]);
+
+	useEffect(() => {
+		getRatings();
+		ratingCreated();
+	}, []);
+
+	async function getRatings() {
+		const ratingsRes = await axios.get(`${envs}/ratings`);
+		setRatings(ratingsRes.data);
+	}
+
+	async function ratingCreated() {
+		getRatings();
+	}
+
+	async function ratingDeleted() {
+		getRatings();
+	}
+
 	return (
 		<div>
 			<Typography variant='h4'>Ratings</Typography>
@@ -32,8 +55,8 @@ export default function Ratings(props) {
 				className={clsx('grid-container', classes.root)}
 				style={{ marginBottom: '1rem' }}
 			>
-				{props.ratings &&
-					props.ratings.map((rating, index) => (
+				{ratings &&
+					ratings.map((rating, index) => (
 						<Grid
 							item
 							xs={12}
@@ -48,13 +71,13 @@ export default function Ratings(props) {
 								rating={rating.rating}
 								key={index}
 								id={rating._id}
-								deleteRating={props.cockpitDeleteCallback}
+								deleteRating={ratingDeleted}
 							/>
 						</Grid>
 					))}
 			</Grid>
 
-			<CreateRating ratingCreated={props.cockpitCreateCallback} />
+			<CreateRating ratingCreated={ratingCreated} />
 		</div>
 	);
 }

--- a/client/src/components/Repos/Repos.js
+++ b/client/src/components/Repos/Repos.js
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import envs from '../../envs/envs';
+import axios from 'axios';
 import Repo from './Repo/Repo';
 
 import Grid from '@material-ui/core/Grid';
@@ -18,6 +20,17 @@ const useStyles = makeStyles((theme) => ({
 
 export default function Repos(props) {
 	const classes = useStyles();
+	const [myRepos, setMyRepos] = useState({ data: [] });
+
+	useEffect(() => {
+		getMyRepos();
+	}, []);
+
+	async function getMyRepos() {
+		const myReposRes = await axios.get(`${envs}/api/my_repos`);
+		setMyRepos(myReposRes.data);
+	}
+
 	return (
 		<Grid
 			container
@@ -25,7 +38,7 @@ export default function Repos(props) {
 			className={clsx('grid-container', classes.root)}
 			style={{ marginBottom: '1rem' }}
 		>
-			{props.repos.map((repo, index) => (
+			{myRepos.data.map((repo, index) => (
 				<Grid
 					item
 					key={index}


### PR DESCRIPTION
I got in the habit of initializing all of the state of the components in `Cockpit FC` and passing them down as props. This PR will move them into their respective components and hopefully address some state wrangling issues I have had in other branches.